### PR TITLE
fix(ci): explicitly select Xcode 26.3 for mobile builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
+      - name: Select Xcode 26.3
+        run: sudo xcode-select -s /Applications/Xcode_26.3.app
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Apple now requires iOS apps to be built with the iOS 26 SDK (Xcode 26+) for App Store submission. macos-latest defaults to Xcode 16.4 which produces an iOS 18.5 SDK build — rejected at upload with error 409.

iOS 17 deployment target (set in previous commit) means Xcode 26 no longer needs the dropped Swift compat shims.